### PR TITLE
Moved "_log" method to the GeneralWorker

### DIFF
--- a/src/GeneralWorker.js
+++ b/src/GeneralWorker.js
@@ -12,6 +12,12 @@ class GeneralWorker {
 		this._onExit = $config.onExit;
 	}
 
+	_log (message) {
+		if (this._debug) {
+			this._logger(`task.js:worker[mid(${this.managerId}) wid(${this.id})]: ${message}`);
+		}
+	}
+
 	handleWorkerExit = () => {
 		this._log('killed');
 		this._onExit(this);

--- a/src/client/CompatibilityWorker.js
+++ b/src/client/CompatibilityWorker.js
@@ -7,12 +7,6 @@ class CompatibilityWorker extends GeneralWorker {
 		this._setTimeoutID = null;
 	}
 
-	_log (message) {
-		if (this._debug) {
-			this._logger(`task.js:worker[mid(${this.managerId}) wid(${this.id})]: ${message}`);
-		}
-	}
-
 	postMessage = (message, options) => {
 		// toss it out of the event loop
 		this._setTimeoutID = setTimeout(() => {

--- a/src/client/WebWorker.js
+++ b/src/client/WebWorker.js
@@ -11,12 +11,6 @@ class WebWorker extends GeneralWorker {
 		this._log(`initialized`);
 	}
 
-	_log (message) {
-		if (this._debug) {
-			this._logger(`task.js:worker[mid(${this.managerId}) wid(${this.id})]: ${message}`);
-		}
-	}
-
 	WORKER_SOURCE = `function () {
 		onmessage = function (event) {
 			var message = event.data;


### PR DESCRIPTION
Hello! I've found that the _`log` method is the same on both workers. In this case, it should better be located in the parent class. The NodeWorker class still overrides it as it has other log message.